### PR TITLE
Feature: composer details for open pull requests

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,7 @@
 use PackageInfo\Command\CacheBuildCommand;
 use PackageInfo\Command\PackageInfoGetCommand;
 use PackageInfo\Command\PackageInfoListCommand;
+use PackageInfo\Command\PackageInfoListNonMatchingRequirementsCommand;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 
@@ -19,6 +20,7 @@ call_user_func(static function() {
         $container->get(CacheBuildCommand::class),
         $container->get(PackageInfoGetCommand::class),
         $container->get(PackageInfoListCommand::class),
+        $container->get(PackageInfoListNonMatchingRequirementsCommand::class),
     ]);
 
     $application->run();

--- a/config/autoload/local-laminas.php.dist
+++ b/config/autoload/local-laminas.php.dist
@@ -17,6 +17,8 @@ return [
         'laminas/technical-steering-committee',
         'laminas/tutorials',
         'laminas/twitter-automation',
+        'laminas/getlaminas.org',
+        'laminas/laminas.dev',
         'laminas-api-tools/.github',
         'mezzio/.github',
         'mezzio/mezzio.dev',

--- a/src/Command/CacheBuildCommand.php
+++ b/src/Command/CacheBuildCommand.php
@@ -23,7 +23,7 @@ use function sprintf;
 class CacheBuildCommand extends Command
 {
     public const OPTION_WITH_PULL_REQUESTS       = 'with-pull-requests';
-    public const OPTION_WITH_PULL_REQUESTS_SHORT = 'wpr';
+    public const OPTION_WITH_PULL_REQUESTS_SHORT = 'p';
     private const PULL_REQUEST_PARAMETERS        = [
         'state' => 'open',
     ];

--- a/src/Command/CacheBuildCommand.php
+++ b/src/Command/CacheBuildCommand.php
@@ -19,13 +19,12 @@ use function file_put_contents;
 use function in_array;
 use function serialize;
 use function sprintf;
-use function var_dump;
 
 class CacheBuildCommand extends Command
 {
-    public const OPTION_WITH_PULL_REQUESTS = 'with-pull-requests';
+    public const OPTION_WITH_PULL_REQUESTS       = 'with-pull-requests';
     public const OPTION_WITH_PULL_REQUESTS_SHORT = 'wpr';
-    private const PULL_REQUEST_PARAMETERS = [
+    private const PULL_REQUEST_PARAMETERS        = [
         'state' => 'open',
     ];
 
@@ -161,11 +160,10 @@ class CacheBuildCommand extends Command
 
         $pullRequests = [];
         foreach ($pullRequestsFromGithub as $pullRequest) {
-
             $instance = new PullRequest(
                 $organization,
                 $repository,
-                    $pullRequest['number'],
+                $pullRequest['number'],
                 $pullRequest['head']['label']
             );
 
@@ -186,7 +184,7 @@ class CacheBuildCommand extends Command
 
             $instance = $instance->withFiles($files);
 
-            if (!$instance->hasComposerChanges()) {
+            if (! $instance->hasComposerChanges()) {
                 continue;
             }
 

--- a/src/Command/PackageInfoListNonMatchingRequirementsCommand.php
+++ b/src/Command/PackageInfoListNonMatchingRequirementsCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PackageInfo\Command;
+
+use PackageInfo\Command\Exception\CacheNotFoundException;
+use PackageInfo\Information\Package;
+use PackageInfo\Information\Requirement;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_diff_key;
+use function array_keys;
+use function array_pop;
+use function count;
+use function file_exists;
+use function file_get_contents;
+use function implode;
+use function sprintf;
+use function unserialize;
+use const PHP_EOL;
+
+final class PackageInfoListNonMatchingRequirementsCommand extends Command
+{
+    private string $cacheFilePath;
+
+    private Requirement $requirement;
+
+    public function __construct(string $cacheFilePath, Requirement $requirement)
+    {
+        $this->cacheFilePath = $cacheFilePath;
+        $this->requirement   = $requirement;
+
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        $this->setName('package-info:list-non-matching-requirements')
+            ->setDescription('List all package information');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (! file_exists($this->cacheFilePath)) {
+            throw CacheNotFoundException::byFilename($this->cacheFilePath);
+        }
+
+        $cacheContent = file_get_contents($this->cacheFilePath);
+        /*** @var Package[] $packages */
+        $packages = unserialize($cacheContent, [false]);
+
+        $output->writeln(sprintf(
+            '<comment>Showing information for <info>%s</info> packages</comment>',
+            count($packages)
+        ));
+        $rows = [];
+
+        foreach ($packages as $key => $package) {
+            [$unmatchedRequirements, $unmatchedDevelopmentRequirements] = $this->unmatchedRequirements($package);
+
+
+            if ($unmatchedRequirements === [] && $unmatchedDevelopmentRequirements === []) {
+                continue;
+            }
+
+            $rows[] = [
+                'package' => $package->toString(),
+                'requirements' => $this->requirementsToString($unmatchedRequirements),
+                'development requirements' => $this->requirementsToString($unmatchedDevelopmentRequirements),
+            ];
+
+            $rows[] = new TableSeparator();
+        }
+
+        // Remove last table separator
+        array_pop($rows);
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(array_keys($rows[0]))
+            ->setRows($rows)
+            ->render();
+
+        return 0;
+    }
+
+    private function unmatchedRequirements(Package $package): array
+    {
+        // First, assume all as unmatched
+        $unmatchedRequirements            = $this->requirement->requirements();
+        $ummatchedDevelopmentRequirements = $this->requirement->developmentRequirements();
+
+        foreach ($package->getBranches() as $branch) {
+            $composerDetails                           = $branch->composerDetails;
+            $unmatchedRequirementsForBranch            = $this->requirement->unmatchedRequirements($composerDetails);
+            $ummatchedDevelopmentRequirementsForBranch = $this->requirement->ummatchedDevelopmentRequirements($composerDetails);
+
+            $unmatchedRequirements            = array_diff_key($unmatchedRequirementsForBranch, $unmatchedRequirements);
+            $ummatchedDevelopmentRequirements = array_diff_key($ummatchedDevelopmentRequirementsForBranch, $ummatchedDevelopmentRequirements);
+
+            if ($unmatchedRequirements === [] && $unmatchedRequirementsForBranch === []) {
+                return [[], []];
+            }
+        }
+
+        foreach ($package->getPullRequests() as $pullRequest) {
+            $composerDetails                           = $pullRequest->composerDetails;
+            $unmatchedRequirementsForBranch            = $this->requirement->unmatchedRequirements($composerDetails);
+            $ummatchedDevelopmentRequirementsForBranch = $this->requirement->ummatchedDevelopmentRequirements($composerDetails);
+
+            $unmatchedRequirements            = array_diff_key($unmatchedRequirementsForBranch, $unmatchedRequirements);
+            $ummatchedDevelopmentRequirements = array_diff_key($ummatchedDevelopmentRequirementsForBranch, $ummatchedDevelopmentRequirements);
+
+            if ($unmatchedRequirements && $ummatchedDevelopmentRequirements) {
+                return [[], []];
+            }
+        }
+
+        return [$unmatchedRequirements, $ummatchedDevelopmentRequirements];
+    }
+
+    private function requirementsToString(array $unmatchedRequirements): string
+    {
+        $requirements = "";
+        foreach ($unmatchedRequirements as $package => $version) {
+            $requirements .= sprintf('%s: %s', $package, $version) . PHP_EOL;
+        }
+
+        return rtrim($requirements);
+    }
+}

--- a/src/Command/PackageInfoListNonMatchingRequirementsCommandFactory.php
+++ b/src/Command/PackageInfoListNonMatchingRequirementsCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PackageInfo\Command;
+
+use PackageInfo\Information\Requirement;
+use Psr\Container\ContainerInterface;
+
+final class PackageInfoListNonMatchingRequirementsCommandFactory
+{
+    public function __invoke(ContainerInterface $container): PackageInfoListNonMatchingRequirementsCommand
+    {
+        $config = $container->get('config');
+
+        return new PackageInfoListNonMatchingRequirementsCommand(
+            $config['cache_file_path'],
+            $container->get(Requirement::class)
+        );
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -11,6 +11,8 @@ use PackageInfo\Command\PackageInfoGetCommand;
 use PackageInfo\Command\PackageInfoGetCommandFactory;
 use PackageInfo\Command\PackageInfoListCommand;
 use PackageInfo\Command\PackageInfoListCommandFactory;
+use PackageInfo\Command\PackageInfoListNonMatchingRequirementsCommand;
+use PackageInfo\Command\PackageInfoListNonMatchingRequirementsCommandFactory;
 use PackageInfo\Information\Requirement;
 use PackageInfo\Information\RequirementFactory;
 
@@ -25,7 +27,9 @@ class ConfigProvider
                     CacheBuildCommand::class      => CacheBuildCommandFactory::class,
                     PackageInfoGetCommand::class  => PackageInfoGetCommandFactory::class,
                     PackageInfoListCommand::class => PackageInfoListCommandFactory::class,
-                    Requirement::class            => RequirementFactory::class,
+                    PackageInfoListNonMatchingRequirementsCommand::class
+                        => PackageInfoListNonMatchingRequirementsCommandFactory::class,
+                    Requirement::class => RequirementFactory::class,
                 ],
             ],
         ];

--- a/src/Information/Exception/UnableToSerializeException.php
+++ b/src/Information/Exception/UnableToSerializeException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace PackageInfo\Information\Exception;
+
+use RuntimeException;
+
+final class UnableToSerializeException extends RuntimeException
+{
+    public static function fromUnresolvedPullRequest(): self
+    {
+        return new self('Cannot serialize unresolved pull request instance.');
+    }
+}

--- a/src/Information/Exception/UnableToSerializeException.php
+++ b/src/Information/Exception/UnableToSerializeException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PackageInfo\Information\Exception;

--- a/src/Information/Package.php
+++ b/src/Information/Package.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PackageInfo\Information;
 
+use Github\Api\PullRequest;
 use PackageInfo\Information\Repository\Branch;
 
 use function sprintf;
@@ -17,14 +18,19 @@ class Package
     /** @var Branch[] */
     private array $branches;
 
+    /** @var PullRequest[] */
+    private array $pullRequests;
+
     public function __construct(
         string $username,
         string $repository,
-        array $branches = []
+        array $branches = [],
+        array $pullRequests = []
     ) {
         $this->setUsername($username);
         $this->setRepository($repository);
         $this->setBranches($branches);
+        $this->setPullRequests($pullRequests);
     }
 
     public function toString(): string
@@ -66,8 +72,24 @@ class Package
         $this->branches[] = $branch;
     }
 
+    /**
+     * @psalm-param list<PullRequest> $pullRequests
+     */
+    public function setPullRequests(array $pullRequests): void
+    {
+        $this->pullRequests = $pullRequests;
+    }
+
     public function setBranches(array $branches): void
     {
         $this->branches = $branches;
+    }
+
+    /**
+     * @return PullRequest[]
+     */
+    public function getPullRequests(): array
+    {
+        return $this->pullRequests;
     }
 }

--- a/src/Information/Package.php
+++ b/src/Information/Package.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PackageInfo\Information;
 
-use Github\Api\PullRequest;
 use PackageInfo\Information\Repository\Branch;
+use PackageInfo\Information\Repository\PullRequest;
 
 use function sprintf;
 

--- a/src/Information/Repository/Branch.php
+++ b/src/Information/Repository/Branch.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace PackageInfo\Information\Repository;
 
-use JsonException;
-
-use function file_get_contents;
-use function json_decode;
 use function sprintf;
-
-use const JSON_THROW_ON_ERROR;
 
 class Branch
 {
     private string $name;
-    private string $composerPackageName    = '';
-    private bool $composerJsonPresent      = false;
-    private string $phpVersion             = 'Undefined';
-    private array $requirements            = [];
-    private array $developmentRequirements = [];
+    /** @var ComposerDetails */
+    private $composerDetails;
 
     public function __construct(
         string $username,
@@ -33,39 +24,8 @@ class Branch
             $name
         );
 
-        $composerJsonPresent = false;
-        $composerJson        = @file_get_contents($composerJsonPath);
-        if (false !== $composerJson) {
-            $composerJsonPresent = true;
-            try {
-                $composer = json_decode($composerJson, true, 512, JSON_THROW_ON_ERROR);
-            } catch (JsonException $e) {
-            }
-        }
-
-        if (isset($composer['name'])) {
-            $this->setComposerPackageName($composer['name']);
-        }
-
-        $requirements = [];
-        if (isset($composer['require'])) {
-            foreach ($composer['require'] as $package => $versionConstraint) {
-                $requirements[$package] = $versionConstraint;
-            }
-        }
-
-        $developmentRequirements = [];
-        if (isset($composer['require-dev'])) {
-            foreach ($composer['require-dev'] as $package => $versionConstraint) {
-                $developmentRequirements[$package] = $versionConstraint;
-            }
-        }
-
+        $this->composerDetails = new ComposerDetails($composerJsonPath);
         $this->setName($name);
-        $this->setComposerJsonPresent($composerJsonPresent);
-        $this->setPhpVersion($composer['require']['php'] ?? 'Undefined');
-        $this->setRequirements($requirements);
-        $this->setDevelopmentRequirements($developmentRequirements);
     }
 
     public function getName(): string
@@ -80,47 +40,27 @@ class Branch
 
     public function getComposerPackageName(): string
     {
-        return $this->composerPackageName;
-    }
-
-    public function setComposerPackageName(string $composerPackageName): void
-    {
-        $this->composerPackageName = $composerPackageName;
+        return $this->composerDetails->composerPackageName;
     }
 
     public function isComposerJsonPresent(): bool
     {
-        return $this->composerJsonPresent;
-    }
-
-    public function setComposerJsonPresent(bool $composerJsonPresent): void
-    {
-        $this->composerJsonPresent = $composerJsonPresent;
+        return $this->composerDetails->composerJsonPresent;
     }
 
     public function getPhpVersion(): string
     {
-        return $this->phpVersion;
-    }
-
-    public function setPhpVersion(string $phpVersion): void
-    {
-        $this->phpVersion = $phpVersion;
+        return $this->composerDetails->phpVersion;
     }
 
     public function getRequirements(): array
     {
-        return $this->requirements;
+        return $this->composerDetails->requirements;
     }
 
     public function getVersionConstraintOfRequirement(string $package): string
     {
-        return $this->requirements[$package];
-    }
-
-    public function addRequirement(string $package, string $versionConstraint): void
-    {
-        $this->requirements[$package] = $versionConstraint;
+        return $this->getRequirements()[$package];
     }
 
     public function hasRequirement(string $package): bool
@@ -128,33 +68,18 @@ class Branch
         return isset($this->getRequirements()[$package]);
     }
 
-    public function setRequirements(array $requirements): void
-    {
-        $this->requirements = $requirements;
-    }
-
     public function getDevelopmentRequirements(): array
     {
-        return $this->developmentRequirements;
+        return $this->composerDetails->developmentRequirements;
     }
 
     public function getVersionConstraintOfDevelopmentRequirement(string $package): string
     {
-        return $this->developmentRequirements[$package];
-    }
-
-    public function addDevelopmentRequirement(string $package, string $versionConstraint): void
-    {
-        $this->developmentRequirements[$package] = $versionConstraint;
+        return $this->getDevelopmentRequirements()[$package];
     }
 
     public function hasDevelopmentRequirement(string $package): bool
     {
         return isset($this->getDevelopmentRequirements()[$package]);
-    }
-
-    public function setDevelopmentRequirements(array $developmentRequirements): void
-    {
-        $this->developmentRequirements = $developmentRequirements;
     }
 }

--- a/src/Information/Repository/Branch.php
+++ b/src/Information/Repository/Branch.php
@@ -9,8 +9,7 @@ use function sprintf;
 class Branch
 {
     private string $name;
-    /** @var ComposerDetails */
-    private $composerDetails;
+    public ComposerDetails $composerDetails;
 
     public function __construct(
         string $username,
@@ -36,50 +35,5 @@ class Branch
     public function setName(string $name): void
     {
         $this->name = $name;
-    }
-
-    public function getComposerPackageName(): string
-    {
-        return $this->composerDetails->composerPackageName;
-    }
-
-    public function isComposerJsonPresent(): bool
-    {
-        return $this->composerDetails->composerJsonPresent;
-    }
-
-    public function getPhpVersion(): string
-    {
-        return $this->composerDetails->phpVersion;
-    }
-
-    public function getRequirements(): array
-    {
-        return $this->composerDetails->requirements;
-    }
-
-    public function getVersionConstraintOfRequirement(string $package): string
-    {
-        return $this->getRequirements()[$package];
-    }
-
-    public function hasRequirement(string $package): bool
-    {
-        return isset($this->getRequirements()[$package]);
-    }
-
-    public function getDevelopmentRequirements(): array
-    {
-        return $this->composerDetails->developmentRequirements;
-    }
-
-    public function getVersionConstraintOfDevelopmentRequirement(string $package): string
-    {
-        return $this->getDevelopmentRequirements()[$package];
-    }
-
-    public function hasDevelopmentRequirement(string $package): bool
-    {
-        return isset($this->getDevelopmentRequirements()[$package]);
     }
 }

--- a/src/Information/Repository/ComposerDetails.php
+++ b/src/Information/Repository/ComposerDetails.php
@@ -1,9 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PackageInfo\Information\Repository;
 
 use JsonException;
+
+use function file_get_contents;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
 
 final class ComposerDetails
 {
@@ -49,6 +55,46 @@ final class ComposerDetails
         }
 
         $this->developmentRequirements = $developmentRequirements;
-        $this->composerJsonPresent = $composerJsonPresent;
+        $this->composerJsonPresent     = $composerJsonPresent;
+    }
+
+    public function isComposerJsonPresent(): bool
+    {
+        return $this->composerJsonPresent;
+    }
+
+    public function getPhpVersion(): string
+    {
+        return $this->phpVersion;
+    }
+
+    public function getRequirements(): array
+    {
+        return $this->requirements;
+    }
+
+    public function getVersionConstraintOfRequirement(string $package): string
+    {
+        return $this->getRequirements()[$package];
+    }
+
+    public function hasRequirement(string $package): bool
+    {
+        return isset($this->getRequirements()[$package]);
+    }
+
+    public function getDevelopmentRequirements(): array
+    {
+        return $this->developmentRequirements;
+    }
+
+    public function getVersionConstraintOfDevelopmentRequirement(string $package): string
+    {
+        return $this->getDevelopmentRequirements()[$package];
+    }
+
+    public function hasDevelopmentRequirement(string $package): bool
+    {
+        return isset($this->getDevelopmentRequirements()[$package]);
     }
 }

--- a/src/Information/Repository/ComposerDetails.php
+++ b/src/Information/Repository/ComposerDetails.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace PackageInfo\Information\Repository;
+
+use JsonException;
+
+final class ComposerDetails
+{
+    public string $composerPackageName = '';
+
+    public bool $composerJsonPresent = false;
+
+    public string $phpVersion = 'Undefined';
+
+    public array $requirements = [];
+
+    public array $developmentRequirements = [];
+
+    public function __construct(string $composerJsonPath)
+    {
+        $composerJsonPresent = false;
+        $composerJson        = @file_get_contents($composerJsonPath);
+        if (false !== $composerJson) {
+            $composerJsonPresent = true;
+            try {
+                $composer = json_decode($composerJson, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                $composer = [];
+            }
+        }
+
+        $this->composerPackageName = $composer['name'] ?? '';
+
+        $requirements = [];
+        if (isset($composer['require'])) {
+            foreach ($composer['require'] as $package => $versionConstraint) {
+                $requirements[$package] = $versionConstraint;
+            }
+        }
+
+        $this->requirements = $requirements;
+
+        $developmentRequirements = [];
+        if (isset($composer['require-dev'])) {
+            foreach ($composer['require-dev'] as $package => $versionConstraint) {
+                $developmentRequirements[$package] = $versionConstraint;
+            }
+        }
+
+        $this->developmentRequirements = $developmentRequirements;
+        $this->composerJsonPresent = $composerJsonPresent;
+    }
+}

--- a/src/Information/Repository/File.php
+++ b/src/Information/Repository/File.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PackageInfo\Information\Repository;
@@ -12,6 +13,6 @@ final class File
     public function __construct(string $filename, string $rawUrl)
     {
         $this->filename = $filename;
-        $this->rawUrl = $rawUrl;
+        $this->rawUrl   = $rawUrl;
     }
 }

--- a/src/Information/Repository/File.php
+++ b/src/Information/Repository/File.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace PackageInfo\Information\Repository;
+
+final class File
+{
+    public string $filename;
+
+    public string $rawUrl;
+
+    public function __construct(string $filename, string $rawUrl)
+    {
+        $this->filename = $filename;
+        $this->rawUrl = $rawUrl;
+    }
+}

--- a/src/Information/Repository/PullRequest.php
+++ b/src/Information/Repository/PullRequest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace PackageInfo\Information\Repository;
+
+use PackageInfo\Information\Exception\UnableToSerializeException;
+use function get_class_vars;
+
+final class PullRequest
+{
+    public const COMPOSER_JSON_FILE = 'composer.json';
+
+    public string $organization;
+
+    public string $repository;
+
+    public int $number;
+
+    public string $head;
+
+    private bool $resolved = false;
+
+    /**
+     * @var File[]
+     */
+    public array $files = [];
+
+    public ComposerDetails $composerDetails;
+
+    public function __construct(string $organization, string $repository, int $number, string $head)
+    {
+        $this->organization = $organization;
+        $this->repository = $repository;
+        $this->number = $number;
+        $this->head = $head;
+    }
+
+    public function hasComposerChanges(): bool
+    {
+        return $this->getComposerJsonFile() !== null;
+    }
+
+    public function __sleep()
+    {
+        if (!$this->resolved) {
+            throw UnableToSerializeException::fromUnresolvedPullRequest();
+        }
+
+        return array_keys(get_class_vars(__CLASS__));
+    }
+
+    public function resolveComposerDetails(): void
+    {
+        $this->resolved = true;
+        $composerJson = $this->getComposerJsonFile();
+        if ($composerJson === null) {
+            return;
+        }
+
+        $this->composerDetails = new ComposerDetails($composerJson->rawUrl);
+    }
+
+    private function getComposerJsonFile(): ?File
+    {
+        foreach ($this->files as $file) {
+            if ($file->filename === self::COMPOSER_JSON_FILE) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param File[] $files
+     */
+    public function withFiles(array $files): self
+    {
+        $instance = clone $this;
+        $instance->files = $files;
+        return $instance;
+    }
+}

--- a/src/Information/Repository/PullRequest.php
+++ b/src/Information/Repository/PullRequest.php
@@ -1,9 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace PackageInfo\Information\Repository;
 
 use PackageInfo\Information\Exception\UnableToSerializeException;
+
+use function array_keys;
 use function get_class_vars;
 
 final class PullRequest
@@ -20,9 +23,7 @@ final class PullRequest
 
     private bool $resolved = false;
 
-    /**
-     * @var File[]
-     */
+    /** @var File[] */
     public array $files = [];
 
     public ComposerDetails $composerDetails;
@@ -30,9 +31,9 @@ final class PullRequest
     public function __construct(string $organization, string $repository, int $number, string $head)
     {
         $this->organization = $organization;
-        $this->repository = $repository;
-        $this->number = $number;
-        $this->head = $head;
+        $this->repository   = $repository;
+        $this->number       = $number;
+        $this->head         = $head;
     }
 
     public function hasComposerChanges(): bool
@@ -42,17 +43,17 @@ final class PullRequest
 
     public function __sleep()
     {
-        if (!$this->resolved) {
+        if (! $this->resolved) {
             throw UnableToSerializeException::fromUnresolvedPullRequest();
         }
 
-        return array_keys(get_class_vars(__CLASS__));
+        return array_keys(get_class_vars(self::class));
     }
 
     public function resolveComposerDetails(): void
     {
         $this->resolved = true;
-        $composerJson = $this->getComposerJsonFile();
+        $composerJson   = $this->getComposerJsonFile();
         if ($composerJson === null) {
             return;
         }
@@ -76,7 +77,7 @@ final class PullRequest
      */
     public function withFiles(array $files): self
     {
-        $instance = clone $this;
+        $instance        = clone $this;
         $instance->files = $files;
         return $instance;
     }

--- a/src/Information/Requirement.php
+++ b/src/Information/Requirement.php
@@ -76,8 +76,7 @@ class Requirement
         );
 
         $constraint    = $this->versionParser->parseConstraints($versionConstraint);
-        $lowerVersion  = $constraint->getLowerBound()->getVersion();
-        $isSupported   = Comparator::greaterThanOrEqualTo($lowerVersion, $minimumVersion);
+        $isSupported   = $constraint->matches($this->versionParser->parseConstraints($minimumVersion));
         $versionFormat = $isSupported === true ? 'info' : 'comment';
 
         return sprintf(


### PR DESCRIPTION
Hey Andi,

as already written in slack, I've added the ability to parse open pull-requests when building the cache.

After this, I've added a command `package-info:list-non-matching-requirements` which provides a list of all packages which does not meet requirements configured in the `local.php`.

When passing `-o` to that command, you get all the package names to conveniently pass to a bash `for` iteration :-) 

Thanks to this repository, I've created tons of new issues in `laminas`, `laminas-api-tools` and `mezzio`. 👍 


_Sadly I've forgot to pass the `--with-pull-requests` to the cache build so I am pretty sure there are issues in repositories which already had a PR open 🙈_ 

However, I appreciated the work on this package as it helped me a lot!

Cheers 🥂 