### PR TITLE
chore: remove unused direct dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,7 @@
         "knplabs/github-api": "^3.16.1",
         "laminas/laminas-config-aggregator": "^1.20",
         "laminas/laminas-servicemanager": "^4.5.1",
-        "laminas/laminas-stdlib": "^3.21",
         "mezzio/mezzio": "^3.28.1",
-        "mezzio/mezzio-helpers": "^5.20",
         "ocramius/package-versions": "^2.12",
         "symfony/console": "^8.1.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a6ce41955cb84e57b067c873bb522eb",
+    "content-hash": "234b445f95a687b5fda3d7ee47a1e6a5",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1193,85 +1193,6 @@
                 }
             ],
             "time": "2026-06-10T09:37:33+00:00"
-        },
-        {
-            "name": "mezzio/mezzio-helpers",
-            "version": "5.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mezzio/mezzio-helpers.git",
-                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
-                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
-                "shasum": ""
-            },
-            "require": {
-                "mezzio/mezzio-router": "^3.18 || ^4.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.0 || ^2.0",
-                "psr/http-message": "^1.0.1 || ^2.0.0",
-                "psr/http-server-middleware": "^1.0"
-            },
-            "conflict": {
-                "amphp/amp": "<2.6.4",
-                "amphp/dns": "<2.1.2",
-                "amphp/socket": "<2.3.1",
-                "zendframework/zend-expressive-helpers": "*"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "laminas/laminas-coding-standard": "~3.1.0",
-                "laminas/laminas-diactoros": "^3.6",
-                "phpunit/phpunit": "^11.5.42",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.13.1"
-            },
-            "suggest": {
-                "ext-json": "If you wish to use the JsonStrategy with BodyParamsMiddleware"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "config-provider": "Mezzio\\Helper\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Mezzio\\Helper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Helper/Utility classes for Mezzio",
-            "homepage": "https://mezzio.dev",
-            "keywords": [
-                "http",
-                "laminas",
-                "mezzio",
-                "middleware",
-                "psr",
-                "psr-7"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.mezzio.dev/mezzio/features/helpers/intro/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/mezzio/mezzio-helpers/issues",
-                "rss": "https://github.com/mezzio/mezzio-helpers/releases.atom",
-                "source": "https://github.com/mezzio/mezzio-helpers"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-10-11T08:40:34+00:00"
         },
         {
             "name": "mezzio/mezzio-router",

--- a/config/config.php
+++ b/config/config.php
@@ -9,7 +9,6 @@ $realPath = realpath(__DIR__);
 assert(is_string($realPath));
 
 $aggregator = new ConfigAggregator([
-    Mezzio\Helper\ConfigProvider::class,
     Mezzio\ConfigProvider::class,
     Mezzio\Router\ConfigProvider::class,
     PackageInfo\ConfigProvider::class,


### PR DESCRIPTION
## Summary

Removes dependencies that are not directly used by the project (only pulled in transitively).

## Changes

- Remove \laminas/laminas-stdlib\ – not directly referenced in source code
- Remove \mezzio/mezzio-helpers\ – not directly referenced; remove corresponding \ConfigProvider\ registration from \config/config.php\

## Verification

All 37 tests pass.