### PR TITLE
perf: fetch composer.json files concurrently using Guzzle Pool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "~8.5.0",
         "ext-json": "*",
         "composer/semver": "^3.4.4",
-        "guzzlehttp/guzzle": "^8.0.2",
+        "guzzlehttp/guzzle": "8.0.2",
         "knplabs/github-api": "^3.16.1",
         "laminas/laminas-config-aggregator": "^1.20",
         "laminas/laminas-servicemanager": "^4.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "234b445f95a687b5fda3d7ee47a1e6a5",
+    "content-hash": "a8a0d5adc6da40f1c31bfa04973a2a27",
     "packages": [
         {
             "name": "brick/varexporter",

--- a/mago-baseline.toml
+++ b/mago-baseline.toml
@@ -27,13 +27,13 @@ count = 2
 [[issues]]
 file = "src/Cache/Branch/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Symfony\Component\Console\Helper\ProgressBar::setMessage`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `PackageInfo\Repository\Head::__construct`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Cache/Branch/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Composer\Json\UrlComposer::__invoke`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Symfony\Component\Console\Helper\ProgressBar::setMessage`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -43,27 +43,21 @@ message = 'Invalid argument type for argument #3 of `PackageInfo\Repository\Head
 count = 1
 
 [[issues]]
+file = "src/Cache/Branch/Builder.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #5 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
+count = 1
+
+[[issues]]
+file = "src/Cache/Branch/Builder.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #6 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
+count = 1
+
+[[issues]]
 file = "src/Cache/Branch/BuilderFactory.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PackageInfo\Cache\Branch\Builder::__construct`: expected `array<array-key, string>`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Cache/Branch/BuilderFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PackageInfo\Cache\Branch\Builder::__construct`: expected `PackageInfo\Composer\Json\UrlComposer`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Cache/Branch/BuilderFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Cache\Branch\Builder::__construct`: expected `PackageInfo\Composer\Json\FileReader`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Cache/Branch/BuilderFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `PackageInfo\Cache\Branch\Builder::__construct`: expected `PackageInfo\Composer\Json\MetaReader`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -153,6 +147,12 @@ count = 1
 [[issues]]
 file = "src/Cache/Builder.php"
 code = "mixed-argument"
+message = 'Invalid argument type for argument #3 of `PackageInfo\Composer\Json\UrlComposer::__invoke`: expected `string`, but found `mixed`.'
+count = 3
+
+[[issues]]
+file = "src/Cache/Builder.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `PackageInfo\Package::__construct`: expected `bool`, but found `mixed`.'
 count = 1
 
@@ -160,13 +160,13 @@ count = 1
 file = "src/Cache/Builder.php"
 code = "mixed-array-access"
 message = "Unsafe array access on type `mixed`."
-count = 2
+count = 6
 
 [[issues]]
 file = "src/Cache/Builder.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 4
+count = 8
 
 [[issues]]
 file = "src/Cache/Builder.php"
@@ -218,6 +218,18 @@ count = 1
 
 [[issues]]
 file = "src/Cache/BuilderFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #7 of `PackageInfo\Cache\Builder::__construct`: expected `PackageInfo\Composer\Json\BatchFetcher`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Cache/BuilderFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #8 of `PackageInfo\Cache\Builder::__construct`: expected `PackageInfo\Composer\Json\UrlComposer`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Cache/BuilderFactory.php"
 code = "mixed-array-access"
 message = "Unsafe array access on type `mixed`."
 count = 1
@@ -231,13 +243,13 @@ count = 1
 [[issues]]
 file = "src/Cache/PullRequest/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Symfony\Component\Console\Helper\ProgressBar::setMessage`: expected `string`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `PackageInfo\Repository\Head::__construct`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Cache/PullRequest/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Composer\Json\UrlComposer::__invoke`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Symfony\Component\Console\Helper\ProgressBar::setMessage`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -247,21 +259,21 @@ message = 'Invalid argument type for argument #3 of `PackageInfo\Repository\Head
 count = 1
 
 [[issues]]
-file = "src/Cache/PullRequest/BuilderFactory.php"
+file = "src/Cache/PullRequest/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PackageInfo\Cache\PullRequest\Builder::__construct`: expected `PackageInfo\Composer\Json\UrlComposer`, but found `mixed`.'
+message = 'Invalid argument type for argument #5 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
 count = 1
 
 [[issues]]
-file = "src/Cache/PullRequest/BuilderFactory.php"
+file = "src/Cache/PullRequest/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PackageInfo\Cache\PullRequest\Builder::__construct`: expected `PackageInfo\Composer\Json\FileReader`, but found `mixed`.'
+message = 'Invalid argument type for argument #6 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
 count = 1
 
 [[issues]]
-file = "src/Cache/PullRequest/BuilderFactory.php"
+file = "src/Cache/Release/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Cache\PullRequest\Builder::__construct`: expected `PackageInfo\Composer\Json\MetaReader`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `PackageInfo\Repository\Head::__construct`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -273,31 +285,19 @@ count = 1
 [[issues]]
 file = "src/Cache/Release/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Composer\Json\UrlComposer::__invoke`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `PackageInfo\Repository\Head::__construct`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Cache/Release/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Repository\Head::__construct`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #5 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
 count = 1
 
 [[issues]]
-file = "src/Cache/Release/BuilderFactory.php"
+file = "src/Cache/Release/Builder.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PackageInfo\Cache\Release\Builder::__construct`: expected `PackageInfo\Composer\Json\UrlComposer`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Cache/Release/BuilderFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PackageInfo\Cache\Release\Builder::__construct`: expected `PackageInfo\Composer\Json\FileReader`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Cache/Release/BuilderFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `PackageInfo\Cache\Release\Builder::__construct`: expected `PackageInfo\Composer\Json\MetaReader`, but found `mixed`.'
+message = 'Invalid argument type for argument #6 of `PackageInfo\Repository\Head::__construct`: expected `array<array-key, mixed>`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -370,6 +370,24 @@ count = 1
 file = "src/CheckCommandFactory.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `PackageInfo\CheckCommand::__construct`: expected `PackageInfo\Requirement\Checker`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Composer/Json/BatchFetcher.php"
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 1
+
+[[issues]]
+file = "src/Composer/Json/BatchFetcher.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #3 of `GuzzleHttp\Pool::__construct`: expected `array{'concurrency'?: (callable(int): int)|int, 'fulfilled'?: (callable(Psr\Http\Message\ResponseInterface, int|string, GuzzleHttp\Promise\PromiseInterface<mixed, mixed>): mixed), 'options'?: array{'allow_redirects'?: array{'max'?: int, 'on_redirect'?: (callable(Psr\Http\Message\RequestInterface, Psr\Http\Message\ResponseInterface, Psr\Http\Message\UriInterface, int|string): mixed), 'protocols'?: non-empty-array<array-key, string>, 'referer'?: bool, 'strict'?: bool, 'track_redirects'?: bool}|bool, 'auth'?: array{0: string, 1: string, 2?: null|string}|false|null|string, 'base_uri'?: Psr\Http\Message\UriInterface|string, 'body'?: Iterator<mixed, mixed>|Psr\Http\Message\StreamInterface|Stringable|has-method<'__invoke'>|null|resource|string, 'cert'?: array{0: string, 1?: null|string}|string, 'cert_type'?: string, 'connect_timeout'?: float|int, 'cookies'?: GuzzleHttp\Cookie\CookieJarInterface|false, 'crypto_method'?: int, 'crypto_method_max'?: int, 'curl'?: array<int|string, mixed>, 'debug'?: bool|resource, 'decode_content'?: bool|string, 'delay'?: float|int, 'expect'?: bool|int, 'force_ip_resolve'?: string, 'form_params'?: array<array-key, array<array-key, mixed>|bool|float|int|null|string>, 'headers'?: array<array-key, non-empty-array<array-key, string>|string>|null, 'http_errors'?: bool, 'idn_conversion'?: bool|int|null, 'json'?: mixed, 'multipart'?: array<array-key, array{'contents': mixed, 'filename'?: string, 'headers'?: array<array-key, string>, 'name': int|string}>, 'multiplex'?: string, 'on_headers'?: (callable(Psr\Http\Message\ResponseInterface, Psr\Http\Message\RequestInterface, int|string): mixed), 'on_stats'?: (callable(GuzzleHttp\TransferStats, int|string): mixed), 'on_trailers'?: (callable(array<string, list<string>>, Psr\Http\Message\ResponseInterface, Psr\Http\Message\RequestInterface, int|string): mixed), 'progress'?: (callable(int, int, int, int, int|string): mixed), 'protocols'?: non-empty-array<array-key, string>, 'proxy'?: array{'http'?: null|string, 'https'?: null|string, 'no'?: array<array-key, string>|null|string}|string, 'query'?: array<array-key, mixed>|string, 'read_timeout'?: float|int, 'request_factory'?: Psr\Http\Message\RequestFactoryInterface, 'response_factory'?: Psr\Http\Message\ResponseFactoryInterface, 'retries'?: int, 'sink'?: Psr\Http\Message\StreamInterface|resource|string, 'ssl_key'?: array{0: string, 1?: null|string}|string, 'ssl_key_type'?: string, 'stream'?: bool, 'stream_context'?: array<array-key, mixed>, 'stream_factory'?: Psr\Http\Message\StreamFactoryInterface, 'synchronous'?: bool, 'timeout'?: float|int, 'uri_factory'?: Psr\Http\Message\UriFactoryInterface, 'verify'?: bool|string, 'version'?: float|int|string, ...}, 'rejected'?: (callable(mixed, int|string, GuzzleHttp\Promise\PromiseInterface<mixed, mixed>): mixed)}`, but possibly received `array{'concurrency': int, 'fulfilled': (closure(Psr\Http\Message\ResponseInterface, string): void), 'rejected': (closure(mixed, string): void)}`.'''
+count = 1
+
+[[issues]]
+file = "src/Composer/Json/BatchFetcher.php"
+code = "unused-parameter"
+message = "Parameter `$reason` is never used."
 count = 1
 
 [[issues]]

--- a/src/Cache/Branch/Builder.php
+++ b/src/Cache/Branch/Builder.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\Branch;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
 use PackageInfo\Package;
 use PackageInfo\Repository\Head;
 use PackageInfo\Repository\Head\Type;
@@ -21,13 +18,14 @@ final readonly class Builder
      */
     public function __construct(
         private array $ignoreBranchNames,
-        private UrlComposer $urlComposer,
-        private FileReader $fileReader,
-        private MetaReader $reader,
     ) {}
 
-    public function __invoke(Package $package, array $branch, ProgressBar $progressBarBranches): Package
-    {
+    public function __invoke(
+        Package $package,
+        array $branch,
+        array $composerData,
+        ProgressBar $progressBarBranches,
+    ): Package {
         $progressBarBranches->setMessage($branch['name']);
         $progressBarBranches->advance();
 
@@ -35,16 +33,13 @@ final readonly class Builder
             return $package;
         }
 
-        $url = ($this->urlComposer)($package->organization, $package->repository, $branch['name']);
-        $this->reader->setComposer(($this->fileReader)($url));
-
         $head = new Head(
-            $this->reader->getPackageName(),
+            $composerData['name'] ?? '',
             Type::Branch->value,
             $branch['name'],
-            $this->reader->isComposerJsonPresent(),
-            $this->reader->getRequirements(),
-            $this->reader->getDevelopmentRequirements(),
+            $composerData !== [],
+            $composerData['require'] ?? [],
+            $composerData['require-dev'] ?? [],
         );
 
         return $package->withHead($head);

--- a/src/Cache/Branch/BuilderFactory.php
+++ b/src/Cache/Branch/BuilderFactory.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\Branch;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -21,11 +18,6 @@ final readonly class BuilderFactory
     {
         $config = $container->get('config');
 
-        return new Builder(
-            $config['ignore_branches'],
-            $container->get(UrlComposer::class),
-            $container->get(FileReader::class),
-            $container->get(MetaReader::class),
-        );
+        return new Builder($config['ignore_branches']);
     }
 }

--- a/src/Cache/Builder.php
+++ b/src/Cache/Builder.php
@@ -9,6 +9,8 @@ use Github\Client;
 use PackageInfo\Cache\Branch\Builder as BranchBuilder;
 use PackageInfo\Cache\PullRequest\Builder as PullRequestBuilder;
 use PackageInfo\Cache\Release\Builder as ReleaseBuilder;
+use PackageInfo\Composer\Json\BatchFetcher;
+use PackageInfo\Composer\Json\UrlComposer;
 use PackageInfo\Console\Helper\ProgressBar;
 use PackageInfo\Package;
 use PackageInfo\PackageContainer\Cache;
@@ -17,6 +19,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 
 use function count;
+use function explode;
 use function in_array;
 use function sprintf;
 
@@ -32,6 +35,8 @@ final class Builder
         private readonly BranchBuilder $branchBuilder,
         private readonly ReleaseBuilder $releaseBuilder,
         private readonly PullRequestBuilder $pullRequestBuilder,
+        private readonly BatchFetcher $batchFetcher,
+        private readonly UrlComposer $urlComposer,
     ) {}
 
     /**
@@ -65,40 +70,75 @@ final class Builder
             }
 
             $branches = $this->client->repo()->branches($package->organization, $package->repository);
+            $releases = $this->client->repo()->releases()->all($package->organization, $package->repository);
+            $pullRequests = $this->client->pullRequests()->all($package->organization, $package->repository);
+
+            $urls = [];
+            foreach ($branches as $i => $branch) {
+                $urls['b:' . $i] = ($this->urlComposer)($package->organization, $package->repository, $branch['name']);
+            }
+            foreach ($releases as $i => $release) {
+                $urls['r:' . $i] = ($this->urlComposer)(
+                    $package->organization,
+                    $package->repository,
+                    $release['tag_name'],
+                );
+            }
+            foreach ($pullRequests as $i => $pullRequest) {
+                $repoFullName = $pullRequest['head']['repo']['full_name'] ?? null;
+                if ($repoFullName !== null) {
+                    [$headOwner, $headRepository] = explode('/', (string) $repoFullName, 2);
+                    $urls['p:' . $i] = ($this->urlComposer)($headOwner, $headRepository, $pullRequest['head']['ref']);
+                }
+            }
+
+            $fetched = $this->batchFetcher->fetch($urls);
 
             if (count($branches) > 0) {
                 $progressBarBranches = new SymfonyProgressBar($this->sectionHeads);
                 $progressBarBranches->setFormat('format_branches');
                 $progressBarBranches->setMaxSteps(count($branches));
 
-                foreach ($branches as $branch) {
-                    $package = ($this->branchBuilder)($package, $branch, $progressBarBranches);
+                foreach ($branches as $i => $branch) {
+                    $package = ($this->branchBuilder)(
+                        $package,
+                        $branch,
+                        $fetched['b:' . $i] ?? [],
+                        $progressBarBranches,
+                    );
                 }
 
                 $this->sectionHeads->clear();
             }
-
-            $releases = $this->client->repo()->releases()->all($package->organization, $package->repository);
 
             if (count($releases) > 0) {
                 $progressBarReleases = new SymfonyProgressBar($this->sectionHeads);
                 $progressBarReleases->setFormat('format_releases');
                 $progressBarReleases->setMaxSteps(count($releases));
 
-                foreach ($releases as $release) {
-                    $package = ($this->releaseBuilder)($package, $release, $progressBarReleases);
+                foreach ($releases as $i => $release) {
+                    $package = ($this->releaseBuilder)(
+                        $package,
+                        $release,
+                        $fetched['r:' . $i] ?? [],
+                        $progressBarReleases,
+                    );
                 }
                 $this->sectionHeads->clear();
             }
 
-            $pullRequests = $this->client->pullRequests()->all($package->organization, $package->repository);
             if (count($pullRequests) > 0) {
                 $progressBarPullRequests = new SymfonyProgressBar($this->sectionHeads);
                 $progressBarPullRequests->setFormat('format_pull_requests');
-                $progressBarPullRequests->setMaxSteps(count($releases));
+                $progressBarPullRequests->setMaxSteps(count($pullRequests));
 
-                foreach ($pullRequests as $pullRequest) {
-                    $package = ($this->pullRequestBuilder)($package, $pullRequest, $progressBarPullRequests);
+                foreach ($pullRequests as $i => $pullRequest) {
+                    $package = ($this->pullRequestBuilder)(
+                        $package,
+                        $pullRequest,
+                        $fetched['p:' . $i] ?? [],
+                        $progressBarPullRequests,
+                    );
                 }
                 $this->sectionHeads->clear();
             }

--- a/src/Cache/BuilderFactory.php
+++ b/src/Cache/BuilderFactory.php
@@ -8,6 +8,8 @@ use Github\Client;
 use PackageInfo\Cache\Branch\Builder as BranchBuilder;
 use PackageInfo\Cache\PullRequest\Builder as PullRequestBuilder;
 use PackageInfo\Cache\Release\Builder as ReleaseBuilder;
+use PackageInfo\Composer\Json\BatchFetcher;
+use PackageInfo\Composer\Json\UrlComposer;
 use PackageInfo\PackageContainer\Cache;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -30,6 +32,8 @@ final readonly class BuilderFactory
             $container->get(BranchBuilder::class),
             $container->get(ReleaseBuilder::class),
             $container->get(PullRequestBuilder::class),
+            $container->get(BatchFetcher::class),
+            $container->get(UrlComposer::class),
         );
     }
 }

--- a/src/Cache/PullRequest/Builder.php
+++ b/src/Cache/PullRequest/Builder.php
@@ -4,47 +4,33 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\PullRequest;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
 use PackageInfo\Package;
 use PackageInfo\Repository\Head;
 use PackageInfo\Repository\Head\Type;
 use Symfony\Component\Console\Helper\ProgressBar;
 
-use function explode;
-
 final readonly class Builder
 {
-    public function __construct(
-        private UrlComposer $urlComposer,
-        private FileReader $fileReader,
-        private MetaReader $reader,
-    ) {}
-
-    public function __invoke(Package $package, array $pullRequest, ProgressBar $progressBarPullRequests): Package
-    {
+    public function __invoke(
+        Package $package,
+        array $pullRequest,
+        array $composerData,
+        ProgressBar $progressBarPullRequests,
+    ): Package {
         $progressBarPullRequests->setMessage($pullRequest['head']['repo']['full_name'] ?? '');
         $progressBarPullRequests->advance();
 
-        $pullRequestExists = ($pullRequest['head']['repo']['full_name'] ?? null) !== null;
-
-        if (!$pullRequestExists) {
+        if (($pullRequest['head']['repo']['full_name'] ?? null) === null) {
             return $package;
         }
 
-        [$headOwner, $headRepository] = explode('/', (string) $pullRequest['head']['repo']['full_name']);
-
-        $url = ($this->urlComposer)($headOwner, $headRepository, $pullRequest['head']['ref']);
-        $this->reader->setComposer(($this->fileReader)($url));
-
         $head = new Head(
-            $this->reader->getPackageName(),
+            $composerData['name'] ?? '',
             Type::PullRequest->value,
             $pullRequest['head']['ref'],
-            $this->reader->isComposerJsonPresent(),
-            $this->reader->getRequirements(),
-            $this->reader->getDevelopmentRequirements(),
+            $composerData !== [],
+            $composerData['require'] ?? [],
+            $composerData['require-dev'] ?? [],
         );
 
         return $package->withHead($head);

--- a/src/Cache/PullRequest/BuilderFactory.php
+++ b/src/Cache/PullRequest/BuilderFactory.php
@@ -4,25 +4,10 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\PullRequest;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-
 final readonly class BuilderFactory
 {
-    /**
-     * @throws NotFoundExceptionInterface
-     * @throws ContainerExceptionInterface
-     */
-    public function __invoke(ContainerInterface $container): Builder
+    public function __invoke(): Builder
     {
-        return new Builder(
-            $container->get(UrlComposer::class),
-            $container->get(FileReader::class),
-            $container->get(MetaReader::class),
-        );
+        return new Builder();
     }
 }

--- a/src/Cache/Release/Builder.php
+++ b/src/Cache/Release/Builder.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\Release;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
 use PackageInfo\Package;
 use PackageInfo\Repository\Head;
 use PackageInfo\Repository\Head\Type;
@@ -14,27 +11,22 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 final readonly class Builder
 {
-    public function __construct(
-        private UrlComposer $urlComposer,
-        private FileReader $fileReader,
-        private MetaReader $reader,
-    ) {}
-
-    public function __invoke(Package $package, array $release, ProgressBar $progressBarReleases): Package
-    {
+    public function __invoke(
+        Package $package,
+        array $release,
+        array $composerData,
+        ProgressBar $progressBarReleases,
+    ): Package {
         $progressBarReleases->setMessage($release['tag_name']);
         $progressBarReleases->advance();
 
-        $url = ($this->urlComposer)($package->organization, $package->repository, $release['tag_name']);
-        $this->reader->setComposer(($this->fileReader)($url));
-
         $head = new Head(
-            $this->reader->getPackageName(),
+            $composerData['name'] ?? '',
             Type::Release->value,
             $release['tag_name'],
-            $this->reader->isComposerJsonPresent(),
-            $this->reader->getRequirements(),
-            $this->reader->getDevelopmentRequirements(),
+            $composerData !== [],
+            $composerData['require'] ?? [],
+            $composerData['require-dev'] ?? [],
         );
 
         return $package->withHead($head);

--- a/src/Cache/Release/BuilderFactory.php
+++ b/src/Cache/Release/BuilderFactory.php
@@ -4,25 +4,10 @@ declare(strict_types=1);
 
 namespace PackageInfo\Cache\Release;
 
-use PackageInfo\Composer\Json\FileReader;
-use PackageInfo\Composer\Json\MetaReader;
-use PackageInfo\Composer\Json\UrlComposer;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-
-final class BuilderFactory
+final readonly class BuilderFactory
 {
-    /**
-     * @throws NotFoundExceptionInterface
-     * @throws ContainerExceptionInterface
-     */
-    public function __invoke(ContainerInterface $container): Builder
+    public function __invoke(): Builder
     {
-        return new Builder(
-            $container->get(UrlComposer::class),
-            $container->get(FileReader::class),
-            $container->get(MetaReader::class),
-        );
+        return new Builder();
     }
 }

--- a/src/Composer/Json/BatchFetcher.php
+++ b/src/Composer/Json/BatchFetcher.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PackageInfo\Composer\Json;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
+
+use function is_array;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+final readonly class BatchFetcher
+{
+    public function __construct(
+        private Client $client,
+        private int $concurrency = 20,
+    ) {}
+
+    /**
+     * @param array<string, string> $urls key => URL
+     * @return array<string, array>       key => parsed composer.json (empty array on error)
+     */
+    public function fetch(array $urls): array
+    {
+        if ($urls === []) {
+            return [];
+        }
+
+        $results = [];
+
+        $requests = (static function () use ($urls) {
+            foreach ($urls as $key => $url) {
+                yield $key => new Request('GET', $url);
+            }
+        })();
+
+        $pool = new Pool($this->client, $requests, [
+            'concurrency' => $this->concurrency,
+            'fulfilled' => static function (ResponseInterface $response, string $key) use (&$results): void {
+                try {
+                    $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+                    $results[$key] = is_array($decoded) ? $decoded : [];
+                } catch (JsonException) {
+                    $results[$key] = [];
+                }
+            },
+            'rejected' => static function (mixed $reason, string $key) use (&$results): void {
+                $results[$key] = [];
+            },
+        ]);
+
+        $pool->promise()->wait();
+
+        return $results;
+    }
+}

--- a/src/Composer/Json/BatchFetcherFactory.php
+++ b/src/Composer/Json/BatchFetcherFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PackageInfo\Composer\Json;
+
+use GuzzleHttp\Client;
+
+final readonly class BatchFetcherFactory
+{
+    public function __invoke(): BatchFetcher
+    {
+        return new BatchFetcher(new Client());
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PackageInfo;
 
 use Github\Client;
+use PackageInfo\Composer\Json\BatchFetcherFactory;
 use PackageInfo\Composer\Json\FileReaderFactory;
 use PackageInfo\Composer\Json\MetaReaderFactory;
 use PackageInfo\Composer\Json\UrlComposerFactory;
@@ -23,6 +24,7 @@ final readonly class ConfigProvider
                     Cache\Release\Builder::class => Cache\Release\BuilderFactory::class,
                     CheckCommand::class => CheckCommandFactory::class,
                     Client::class => GithubClientFactory::class,
+                    Composer\Json\BatchFetcher::class => BatchFetcherFactory::class,
                     Composer\Json\FileReader::class => FileReaderFactory::class,
                     Composer\Json\MetaReader::class => MetaReaderFactory::class,
                     Composer\Json\UrlComposer::class => UrlComposerFactory::class,

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -11,6 +11,7 @@ use PackageInfo\Cache\Builder;
 use PackageInfo\Cache\PullRequest\Builder as PullRequestBuilder;
 use PackageInfo\Cache\Release\Builder as ReleaseBuilder;
 use PackageInfo\CheckCommand;
+use PackageInfo\Composer\Json\BatchFetcher as ComposerJsonBatchFetcher;
 use PackageInfo\Composer\Json\FileReader as ComposerJsonFileReader;
 use PackageInfo\Composer\Json\MetaReader as ComposerJsonMetaReader;
 use PackageInfo\Composer\Json\UrlComposer as ComposerJsonUrlComposer;
@@ -44,7 +45,7 @@ final class ConfigProviderTest extends TestCase
         static::assertIsArray($config['dependencies']);
         static::assertArrayHasKey('factories', $config['dependencies']);
         static::assertIsArray($config['dependencies']['factories']);
-        static::assertCount(16, $config['dependencies']['factories']);
+        static::assertCount(17, $config['dependencies']['factories']);
         static::assertArrayHasKey(BranchBuilder::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(BuildCommand::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(Builder::class, $config['dependencies']['factories']);
@@ -52,6 +53,7 @@ final class ConfigProviderTest extends TestCase
         static::assertArrayHasKey(CheckCommand::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(Checker::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(Client::class, $config['dependencies']['factories']);
+        static::assertArrayHasKey(ComposerJsonBatchFetcher::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(ComposerJsonFileReader::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(ComposerJsonMetaReader::class, $config['dependencies']['factories']);
         static::assertArrayHasKey(ComposerJsonUrlComposer::class, $config['dependencies']['factories']);


### PR DESCRIPTION
## Summary

Replace sequential \ile_get_contents()\ calls with concurrent HTTP requests via \GuzzleHttp\Pool\. For each repository, all \composer.json\ URLs (branches, releases, pull requests) are now collected first, then fetched in parallel with up to 20 concurrent connections.

## Performance

| Organization | Before | After |
|---|---|---|
| laminas (137 repos) | ~20 min | ~5 min |
| mezzio (36 repos) | ~12 min | ~1 min 28 s |

## Changes

- Add \Composer\Json\BatchFetcher\ using \GuzzleHttp\Pool\ for concurrent fetching
- Add \Composer\Json\BatchFetcherFactory\
- Simplify \Cache\Branch\Builder\, \Cache\Release\Builder\ and \Cache\PullRequest\Builder\: remove \FileReader\, \UrlComposer\ and \MetaReader\ dependencies; accept pre-fetched composer data directly
- Refactor \Cache\Builder\ to collect all URLs per repository, batch-fetch them concurrently, then pass data to sub-builders
- Fix bug: pull request progress bar was using \count(\)\ instead of \count(\)\
- Add \guzzlehttp/guzzle\ as direct dependency (was transitive only)

## Verification

All 37 tests pass. \mago lint\, \mago format --check\, and \mago analyze --baseline mago-baseline.toml\ report no issues.